### PR TITLE
chore: update @types/node to version 24.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@semantic-release/git": "^10.0.1",
     "@types/dotenv": "^8.2.3",
     "@types/inquirer": "^9.0.8",
-    "@types/node": "^24.0.15",
+    "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
     "@vitest/coverage-v8": "^3.2.4",


### PR DESCRIPTION
chore(deps): update @types/node to version 24.1.0

This pull request updates the @types/node package to version 24.1.0. The main changes include the update of the package version in package.json. This update ensures compatibility with the latest Node.js features and improvements.